### PR TITLE
Remove vulnerable Rake dependency, update to Jekyll 4.0

### DIFF
--- a/names_are_hard.gemspec
+++ b/names_are_hard.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README)}i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.6"
+  spec.add_runtime_dependency "jekyll", "~> 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
 end


### PR DESCRIPTION
This PR removes a dependency on a vulnerable version of `rake`, and updates the version of Jekyll to 4.0